### PR TITLE
refactor: unify subscription status logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@bubblewrap/cli": "^1.23.0",
@@ -89,6 +90,9 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.6.0",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/jest-dom": "^6.4.5"
   }
 }

--- a/src/components/SimpleSubscriptionStatus.tsx
+++ b/src/components/SimpleSubscriptionStatus.tsx
@@ -2,50 +2,17 @@ import React from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { ExternalLink, Clock } from 'lucide-react';
-import { useAccess } from '@/hooks/useAccess';
+import { useSubscriptionStatus } from '@/hooks/useSubscriptionStatus';
 
 export const SimpleSubscriptionStatus: React.FC = () => {
-  const { 
-    hasPremiumFeatures, 
+  const {
+    hasPremiumFeatures,
     access_level,
     isTrial,
     daysRemaining,
-    openCustomerPortal 
-  } = useAccess();
-
-  const getStatusInfo = () => {
-    if (access_level === 'admin') {
-      return {
-        status: 'Admin Account',
-        description: 'Full access to all features',
-        variant: 'default' as const
-      };
-    }
-    
-    if (hasPremiumFeatures) {
-      return {
-        status: 'Premium Active',
-        description: 'All features unlocked',
-        variant: 'default' as const
-      };
-    }
-    
-    if (isTrial) {
-      return {
-        status: 'Free Trial',
-        description: `${daysRemaining} days remaining`,
-        variant: 'secondary' as const
-      };
-    }
-    
-    return {
-      status: 'Free Account',
-      description: 'Limited features',
-      variant: 'outline' as const
-    };
-  };
-
-  const statusInfo = getStatusInfo();
+    openCustomerPortal,
+    statusInfo
+  } = useSubscriptionStatus();
 
   return (
     <div className="space-y-4">

--- a/src/components/SubscriptionStatus.tsx
+++ b/src/components/SubscriptionStatus.tsx
@@ -3,16 +3,17 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { CreditCard, Calendar, ExternalLink, Clock, Crown } from 'lucide-react';
-import { useAccess } from '@/hooks/useAccess';
+import { useSubscriptionStatus } from '@/hooks/useSubscriptionStatus';
 
 export const SubscriptionStatus: React.FC = () => {
-  const { 
-    hasPremiumFeatures, 
+  const {
+    hasPremiumFeatures,
     access_level,
     isTrial,
     daysRemaining,
-    openCustomerPortal 
-  } = useAccess();
+    openCustomerPortal,
+    statusInfo
+  } = useSubscriptionStatus();
 
   const getNextBillingDate = () => {
     if (isTrial && daysRemaining) {
@@ -23,44 +24,6 @@ export const SubscriptionStatus: React.FC = () => {
     // For actual subscriptions, this would come from Stripe data
     return "N/A";
   };
-
-  const getStatusInfo = () => {
-    if (access_level === 'admin') {
-      return {
-        status: 'Admin Account',
-        description: 'Full access to all features',
-        variant: 'default' as const,
-        showBilling: false
-      };
-    }
-    
-    if (hasPremiumFeatures) {
-      return {
-        status: 'Active Subscription',
-        description: 'Premium features enabled',
-        variant: 'default' as const,
-        showBilling: true
-      };
-    }
-    
-    if (isTrial) {
-      return {
-        status: 'Free Trial',
-        description: `${daysRemaining} days remaining`,
-        variant: 'secondary' as const,
-        showBilling: true
-      };
-    }
-    
-    return {
-      status: 'Free Account',
-      description: 'Limited features available',
-      variant: 'outline' as const,
-      showBilling: false
-    };
-  };
-
-  const statusInfo = getStatusInfo();
 
   return (
     <Card>

--- a/src/hooks/useSubscriptionStatus.test.tsx
+++ b/src/hooks/useSubscriptionStatus.test.tsx
@@ -1,0 +1,78 @@
+import { renderHook } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi, describe, it, expect } from 'vitest';
+import { useSubscriptionStatus } from './useSubscriptionStatus';
+import { useAccess } from '@/hooks/useAccess';
+
+vi.mock('@/hooks/useAccess');
+const mockUseAccess = useAccess as unknown as ReturnType<typeof vi.fn>;
+
+describe('useSubscriptionStatus', () => {
+  it('returns admin status info', () => {
+    mockUseAccess.mockReturnValue({
+      hasPremiumFeatures: true,
+      access_level: 'admin',
+      isTrial: false,
+      daysRemaining: null,
+      openCustomerPortal: vi.fn(),
+    });
+    const { result } = renderHook(() => useSubscriptionStatus());
+    expect(result.current.statusInfo).toEqual({
+      status: 'Admin Account',
+      description: 'Full access to all features',
+      variant: 'default',
+      showBilling: false,
+    });
+  });
+
+  it('returns premium status info', () => {
+    mockUseAccess.mockReturnValue({
+      hasPremiumFeatures: true,
+      access_level: 'premium',
+      isTrial: false,
+      daysRemaining: null,
+      openCustomerPortal: vi.fn(),
+    });
+    const { result } = renderHook(() => useSubscriptionStatus());
+    expect(result.current.statusInfo).toEqual({
+      status: 'Active Subscription',
+      description: 'Premium features enabled',
+      variant: 'default',
+      showBilling: true,
+    });
+  });
+
+  it('returns trial status info', () => {
+    mockUseAccess.mockReturnValue({
+      hasPremiumFeatures: true,
+      access_level: 'trial',
+      isTrial: true,
+      daysRemaining: 5,
+      openCustomerPortal: vi.fn(),
+    });
+    const { result } = renderHook(() => useSubscriptionStatus());
+    expect(result.current.statusInfo).toEqual({
+      status: 'Free Trial',
+      description: '5 days remaining',
+      variant: 'secondary',
+      showBilling: true,
+    });
+  });
+
+  it('returns free status info', () => {
+    mockUseAccess.mockReturnValue({
+      hasPremiumFeatures: false,
+      access_level: 'free',
+      isTrial: false,
+      daysRemaining: null,
+      openCustomerPortal: vi.fn(),
+    });
+    const { result } = renderHook(() => useSubscriptionStatus());
+    expect(result.current.statusInfo).toEqual({
+      status: 'Free Account',
+      description: 'Limited features available',
+      variant: 'outline',
+      showBilling: false,
+    });
+  });
+});

--- a/src/hooks/useSubscriptionStatus.ts
+++ b/src/hooks/useSubscriptionStatus.ts
@@ -1,0 +1,59 @@
+import { useMemo } from 'react';
+import { useAccess } from '@/hooks/useAccess';
+
+export const useSubscriptionStatus = () => {
+  const {
+    hasPremiumFeatures,
+    access_level,
+    isTrial,
+    daysRemaining,
+    openCustomerPortal,
+  } = useAccess();
+
+  const statusInfo = useMemo(() => {
+    if (access_level === 'admin') {
+      return {
+        status: 'Admin Account',
+        description: 'Full access to all features',
+        variant: 'default' as const,
+        showBilling: false,
+      };
+    }
+
+    if (hasPremiumFeatures) {
+      return {
+        status: 'Active Subscription',
+        description: 'Premium features enabled',
+        variant: 'default' as const,
+        showBilling: true,
+      };
+    }
+
+    if (isTrial) {
+      return {
+        status: 'Free Trial',
+        description: `${daysRemaining} days remaining`,
+        variant: 'secondary' as const,
+        showBilling: true,
+      };
+    }
+
+    return {
+      status: 'Free Account',
+      description: 'Limited features available',
+      variant: 'outline' as const,
+      showBilling: false,
+    };
+  }, [access_level, hasPremiumFeatures, isTrial, daysRemaining]);
+
+  return {
+    hasPremiumFeatures,
+    access_level,
+    isTrial,
+    daysRemaining,
+    openCustomerPortal,
+    statusInfo,
+  };
+};
+
+export type SubscriptionStatusInfo = ReturnType<typeof useSubscriptionStatus>['statusInfo'];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,5 +48,8 @@ export default defineConfig(async ({ mode }) => {
       // Ensure environment detection works
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || mode),
     },
+    test: {
+      environment: 'jsdom',
+    },
   };
 });


### PR DESCRIPTION
## Summary
- add `useSubscriptionStatus` hook for shared subscription state
- refactor subscription status components to consume the hook
- configure Vitest and add tests for `useSubscriptionStatus`

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: 353 errors, 80 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c580943f18832c8775d3a2e82615e0