### PR TITLE
chore: archive deprecated subscription hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Fast Now is a comprehensive nutrition and meal tracking application that helps y
 - **Progress Insights**: Track your nutritional goals and progress over time
 - **Cross-Platform**: Available on web, iOS, and Android
 
+## Access & Subscriptions
+
+Use the `useAccess` hook to handle user access levels and subscription state. Legacy hooks such as `useSubscription` and `useUnifiedSubscription` have been moved to `legacy/hooks` for reference and should not be used in new code.
+
 ## Building the Android AAB
 
 To build the Android App Bundle (AAB) from a fresh git clone:

--- a/legacy/hooks/useSubscription.tsx
+++ b/legacy/hooks/useSubscription.tsx
@@ -7,7 +7,7 @@
  * Migration complete on: 2024-12-XX
  */
 
-import { useAccess } from './useAccess';
+import { useAccess } from '../../src/hooks/useAccess';
 
 export const useSubscription = () => {
   console.warn('🚨 useSubscription is DEPRECATED. Use useAccess instead.');

--- a/legacy/hooks/useUnifiedSubscription.tsx
+++ b/legacy/hooks/useUnifiedSubscription.tsx
@@ -11,7 +11,7 @@
  * - Direct Supabase functions for subscription management
  */
 
-import { useAccess } from './useAccess';
+import { useAccess } from '../../src/hooks/useAccess';
 
 export const useUnifiedSubscription = () => {
   console.warn('🚨 useUnifiedSubscription is DEPRECATED. Use useAccess instead.');


### PR DESCRIPTION
## Summary
- move deprecated subscription hooks into a `legacy/hooks` folder
- document that `useAccess` replaces the old subscription hooks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 433 problems (353 errors, 80 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68c580964c14832ca5b481daf24e9824