### PR TITLE
Clear React Query caches on auth events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+test-dist
 *.local
 
 # Editor directories and files

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "rm -rf test-dist && tsc src/hooks/useAuthCacheManager.tsx src/hooks/useAuthCacheManager.test.tsx --outDir test-dist --module commonjs --moduleResolution node --jsx react-jsx --esModuleInterop --target es2019 && node --test test-dist/useAuthCacheManager.test.js"
   },
   "dependencies": {
     "@capacitor/android": "^7.4.2",

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -164,11 +164,8 @@ export const useAuth = () => {
 
   const signOut = async () => {
     const operation = async () => {
-      // Clear all caches before signing out
-      clearAllAuthCaches();
-      
       const result = await authState.signOut();
-      
+
       if (result?.error) {
         toast({
           title: "Sign Out Failed",
@@ -176,6 +173,8 @@ export const useAuth = () => {
           variant: "destructive",
         });
       } else {
+        // Clear all caches only after a successful sign out
+        clearAllAuthCaches();
         toast({
           title: "Signed Out",
           description: "You have been successfully signed out.",

--- a/src/hooks/useAuthCacheManager.test.tsx
+++ b/src/hooks/useAuthCacheManager.test.tsx
@@ -1,0 +1,60 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderToString } from 'react-dom/server';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { useAuthCacheManager } from './useAuthCacheManager';
+
+// Enhanced localStorage polyfill that exposes keys for Object.keys
+class LocalStorageMock {
+  private store: Record<string, string>;
+  constructor() {
+    this.store = {};
+  }
+  getItem(key: string) {
+    return Object.prototype.hasOwnProperty.call(this.store, key) ? this.store[key] : null;
+  }
+  setItem(key: string, value: string) {
+    this.store[key] = value;
+    (this as any)[key] = value;
+  }
+  removeItem(key: string) {
+    delete this.store[key];
+    delete (this as any)[key];
+  }
+  clear() {
+    Object.keys(this.store).forEach(key => this.removeItem(key));
+  }
+  key(index: number) {
+    return Object.keys(this.store)[index] ?? null;
+  }
+}
+
+(globalThis as any).localStorage = new LocalStorageMock();
+(globalThis as any).window = { localStorage: (globalThis as any).localStorage };
+
+test('clearAllAuthCaches removes query data and persisted storage', () => {
+  const queryClient = new QueryClient();
+  queryClient.setQueryData(['example'], { foo: 'bar' });
+  localStorage.setItem('REACT_QUERY_OFFLINE_CACHE', 'persisted');
+  localStorage.setItem('cache_profile_test', 'data');
+
+  let manager: ReturnType<typeof useAuthCacheManager> | undefined;
+  function TestComponent() {
+    manager = useAuthCacheManager();
+    return null;
+  }
+
+  renderToString(
+    <QueryClientProvider client={queryClient}>
+      <TestComponent />
+    </QueryClientProvider>
+  );
+
+  assert.equal(queryClient.getQueryCache().getAll().length, 1);
+
+  manager!.clearAllAuthCaches();
+
+  assert.equal(queryClient.getQueryCache().getAll().length, 0);
+  assert.equal(localStorage.getItem('REACT_QUERY_OFFLINE_CACHE'), null);
+  assert.equal(localStorage.getItem('cache_profile_test'), null);
+});

--- a/src/hooks/useAuthCacheManager.tsx
+++ b/src/hooks/useAuthCacheManager.tsx
@@ -9,15 +9,17 @@ export const useAuthCacheManager = () => {
   const queryClient = useQueryClient();
 
   const clearAllAuthCaches = useCallback(() => {
-    // Clear React Query caches for auth-related data
-    queryClient.invalidateQueries({ queryKey: ['access'] });
-    queryClient.invalidateQueries({ queryKey: ['profile'] });
-    
-    // Clear localStorage caches
+    // Fully clear React Query caches
+    queryClient.clear();
+
+    // Clear localStorage caches including persisted query data
     if (typeof window !== 'undefined') {
+      // Remove React Query persister storage
+      localStorage.removeItem('REACT_QUERY_OFFLINE_CACHE');
+
       const keys = Object.keys(localStorage);
       keys.forEach(key => {
-        if (key.startsWith('cache_profile_') || 
+        if (key.startsWith('cache_profile_') ||
             key.startsWith('dedupe_profile_') ||
             key.startsWith('cache_access_') ||
             key.startsWith('dedupe_access_')) {
@@ -25,7 +27,7 @@ export const useAuthCacheManager = () => {
         }
       });
     }
-    
+
     console.log('🧹 Cleared all authentication caches');
   }, [queryClient]);
 


### PR DESCRIPTION
## Summary
- Clear React Query caches and persisted storage in `useAuthCacheManager`
- Ensure sign-out clears caches only after successful logout
- Add regression test verifying no auth caches remain after logout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c58be85218832c9cee7500097193dc